### PR TITLE
Update OHLC, json_decode Oanda ticker item

### DIFF
--- a/app/Traits/OHLC.php
+++ b/app/Traits/OHLC.php
@@ -29,6 +29,7 @@ trait OHLC
             $timeid = ($ticker['timeid'] ?? $timeid);
         } else {
             /** Oanda websocket */
+            $ticker = json_decode($ticker, true);
             $last_price = $ticker['tick']['bid'];
             $instrument = $ticker['tick']['instrument'];
             $volume = 0;


### PR DESCRIPTION
Oanda ticker item is json string, so it has to be decoded to an associative array.